### PR TITLE
Tables name with special character

### DIFF
--- a/lib/pg_partition_manager.rb
+++ b/lib/pg_partition_manager.rb
@@ -31,10 +31,10 @@ module PgPartitionManager
 
       result = @db.exec("select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = '#{schema}' and relname like '#{table}_p%' and relkind = 'r' and relname < '#{table}_p#{table_suffix}' order by 1, 2")
       result.map do |row|
-        child_table = "#{row["nspname"]}.#{row["relname"]}"
+        child_table = "\"#{row["nspname"]}.#{row["relname"]}\""
 
         # set a default statement
-        statement = "drop table if exists \"#{child_table}\""
+        statement = "drop table if exists #{child_table}"
 
         # update the statement if they want the cascade or the truncate option
         if @partition[:cascade] == true

--- a/lib/pg_partition_manager.rb
+++ b/lib/pg_partition_manager.rb
@@ -34,7 +34,7 @@ module PgPartitionManager
         child_table = "#{row["nspname"]}.#{row["relname"]}"
 
         # set a default statement
-        statement = "drop table if exists #{child_table}"
+        statement = "drop table if exists \"#{child_table}\""
 
         # update the statement if they want the cascade or the truncate option
         if @partition[:cascade] == true
@@ -74,7 +74,7 @@ module PgPartitionManager
           pg_start = start
           pg_stop = stop
         end
-        @db.exec("create table if not exists #{child_table} partition of #{schema}.#{table} for values from ('#{pg_start}') to ('#{pg_stop}')")
+        @db.exec("create table if not exists \"#{child_table}\" partition of \"#{schema}.#{table}\" for values from ('#{pg_start}') to ('#{pg_stop}')")
         start = stop
         stop = period_end(start)
         child_table

--- a/lib/pg_partition_manager.rb
+++ b/lib/pg_partition_manager.rb
@@ -29,13 +29,7 @@ module PgPartitionManager
       schema, table = @partition[:parent_table].split(".")
       table_suffix = retention.to_s.tr("-", "_")
 
-      tbname_has_specials = contains_special_character?(table)
-      if tbname_has_specials
-        query = "select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = '#{schema}' and relname like \"#{table}_p%\" and relkind = 'r' and relname < \"#{table}_p#{table_suffix}\" order by 1, 2"
-      else
-        query = "select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = '#{schema}' and relname like '#{table}_p%' and relkind = 'r' and relname < '#{table}_p#{table_suffix}' order by 1, 2"
-      end
-
+      query = "select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = '#{schema}' and relname like '#{table}_p%' and relkind = 'r' and relname < '#{table}_p#{table_suffix}' order by 1, 2"
       result = @db.exec(query)
       result.map do |row|
         tbname_has_specials = contains_special_character?(row["relname"])

--- a/lib/pg_partition_manager.rb
+++ b/lib/pg_partition_manager.rb
@@ -29,9 +29,17 @@ module PgPartitionManager
       schema, table = @partition[:parent_table].split(".")
       table_suffix = retention.to_s.tr("-", "_")
 
-      result = @db.exec("select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = '#{schema}' and relname like '#{table}_p%' and relkind = 'r' and relname < '#{table}_p#{table_suffix}' order by 1, 2")
+      tbname_has_specials = contains_special_character?(table)
+      if tbname_has_specials
+        query = "select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = '#{schema}' and relname like \"#{table}_p%\" and relkind = 'r' and relname < \"#{table}_p#{table_suffix}\" order by 1, 2"
+      else
+        query = "select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = '#{schema}' and relname like '#{table}_p%' and relkind = 'r' and relname < '#{table}_p#{table_suffix}' order by 1, 2"
+      end
+
+      result = @db.exec(query)
       result.map do |row|
-        child_table = "\"#{row["nspname"]}.#{row["relname"]}\""
+        tbname_has_specials = contains_special_character?(row["relname"])
+        child_table = tbname_has_specials ? "\"#{row["nspname"]}.#{row["relname"]}\"" : "#{row["nspname"]}.#{row["relname"]}"
 
         # set a default statement
         statement = "drop table if exists #{child_table}"
@@ -63,7 +71,14 @@ module PgPartitionManager
       # than 1 for the range, to be sure the current period gets a table *and*
       # we make the number of desired future tables
       (0..(@partition[:premake] || 4)).map do |month|
-        child_table = "#{schema}.#{table}_p#{start.to_s.tr("-", "_")}"
+        tbname_has_specials = contains_special_character?(table)
+        if tbname_has_specials
+          child_table = "\"#{schema}.#{table}_p#{start.to_s.tr("-", "_")}\""
+          partition_table = "\"#{schema}.#{table}\""
+        else
+          child_table = "#{schema}.#{table}_p#{start.to_s.tr("-", "_")}"
+          partition_table = "#{schema}.#{table}"
+        end
 
         if @partition[:ulid] == true
           # ULID is lexographic https://github.com/rafaelsales/ulid
@@ -74,7 +89,7 @@ module PgPartitionManager
           pg_start = start
           pg_stop = stop
         end
-        @db.exec("create table if not exists \"#{child_table}\" partition of \"#{schema}.#{table}\" for values from ('#{pg_start}') to ('#{pg_stop}')")
+        @db.exec("create table if not exists #{child_table} partition of #{partition_table} for values from ('#{pg_start}') to ('#{pg_stop}')")
         start = stop
         stop = period_end(start)
         child_table
@@ -113,6 +128,10 @@ module PgPartitionManager
         pm.drop_tables
         pm.create_tables
       end
+    end
+
+    def contains_special_character?(table_name)
+      table_name.match(/[-!@#$%^&*(),.?":{}|<>]/).present? ? true : false
     end
   end
 end

--- a/test/pg_partition_manager_test.rb
+++ b/test/pg_partition_manager_test.rb
@@ -110,7 +110,7 @@ class PgPartitionManagerTest < Minitest::Test
     PG.stub :connect, db do
       Date.stub :today, Date.new(2019, 10, 1) do
         pm = PgPartitionManager::Time.new({parent_table: "public.events_8555b191-e0da-4869-a8a5-eba524a8e4ea", period: "month", retain: 2})
-        db.expect(:exec, [{"nspname" => "public", "relname" => "events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_10_17" }], ["select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = 'public' and relname like \"events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p%\" and relkind = 'r' and relname < \"events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_08_01\" order by 1, 2"])
+        db.expect(:exec, [{"nspname" => "public", "relname" => 'events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_10_17' }], ["select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = 'public' and relname like 'events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p%' and relkind = 'r' and relname < 'events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_08_01' order by 1, 2"])
         db.expect(:exec, true, ["drop table if exists \"public.events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_10_17\""])
         pm.drop_tables
       end

--- a/test/pg_partition_manager_test.rb
+++ b/test/pg_partition_manager_test.rb
@@ -93,6 +93,31 @@ class PgPartitionManagerTest < Minitest::Test
     db.verify
   end
 
+  def test_it_creates_tables_with_special_characters
+    PG.stub :connect, db do
+      Date.stub :today, Date.new(2019, 10, 11) do
+        pm = PgPartitionManager::Time.new({parent_table: "public.events_8555b191-e0da-4869-a8a5-eba524a8e4ea", period: "day"})
+        (11..15).each do |d|
+          db.expect(:exec, true, ["create table if not exists \"public.events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_10_#{d}\" partition of \"public.events_8555b191-e0da-4869-a8a5-eba524a8e4ea\" for values from ('2019-10-#{d}') to ('2019-10-#{d + 1}')"])
+        end
+        pm.create_tables
+      end
+    end
+    db.verify
+  end
+
+  def test_it_drops_tables_with_special_characters
+    PG.stub :connect, db do
+      Date.stub :today, Date.new(2019, 10, 1) do
+        pm = PgPartitionManager::Time.new({parent_table: "public.events_8555b191-e0da-4869-a8a5-eba524a8e4ea", period: "month", retain: 2})
+        db.expect(:exec, [{"nspname" => "public", "relname" => "events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_10_17" }], ["select nspname, relname from pg_class c inner join pg_namespace n on n.oid = c.relnamespace where nspname = 'public' and relname like \"events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p%\" and relkind = 'r' and relname < \"events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_08_01\" order by 1, 2"])
+        db.expect(:exec, true, ["drop table if exists \"public.events_8555b191-e0da-4869-a8a5-eba524a8e4ea_p2019_10_17\""])
+        pm.drop_tables
+      end
+    end
+    db.verify
+  end
+
   def db
     @db ||= Minitest::Mock.new
   end


### PR DESCRIPTION
The changes in this pull request enables to create and drop partitioned tables that contains special characters.
I came up with this solutions because i was trying to use this gem to create partitioned tables by list of a column which type is 'uuids', but to create tables with special characters it must be between double quotes.